### PR TITLE
5 supporting lowercase path for subpath

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -65,7 +65,7 @@ impl CellHeader {
 /// 
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// # let hive_file = File::open("tests/data/testhive")?;
-/// # let mut hive = Hive::new(hive_file)?;
+/// # let mut hive = Hive::new(hive_file, HiveParseMode::NormalWithBaseBlock)?;
 /// # let offset = hive.root_cell_offset();
 /// hive.seek(SeekFrom::Start(offset.0.into()))?;
 /// let cell: Cell<KeyNodeWithMagic, ()> = hive.read_le().unwrap();

--- a/src/hive.rs
+++ b/src/hive.rs
@@ -129,7 +129,7 @@ where
     /// 
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// # let hive_file = File::open("tests/data/testhive")?;
-    /// # let mut hive = Hive::new(hive_file)?;
+    /// # let mut hive = Hive::new(hive_file, HiveParseMode::NormalWithBaseBlock)?;
     /// # let offset = hive.root_cell_offset();
     /// let my_node: KeyNodeWithMagic = hive.read_structure(offset)?;
     /// # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! #
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //! let hive_file = File::open("tests/data/testhive")?;
-//! let mut hive = Hive::new(hive_file)?;
+//! let mut hive = Hive::new(hive_file, HiveParseMode::NormalWithBaseBlock)?;
 //! let root_key = hive.root_key_node()?;
 //! 
 //! for sk in root_key.subkeys(&mut hive)?.iter() {

--- a/src/nk.rs
+++ b/src/nk.rs
@@ -221,10 +221,18 @@ impl KeyNode
     }
 
     /// returns the subkey with a given `name`, of [None] if there is no such subkey.
+    /// The name is compared without case sensitivity, because
+    /// 
+    /// > Each key has a name consisting of one or more printable characters.
+    /// > *Key names are not case sensitive.* Key names cannot include the backslash character (\),
+    /// > but any other printable character can be used. Value names and data can include the backslash character.
+    /// 
+    /// (<https://learn.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry>)
     pub fn subkey<B>(&self, name: &str, hive: &mut Hive<B>) -> BinResult<Option<Rc<RefCell<Self>>>> where B: BinReaderExt {
+        let lowercase_name = name.to_lowercase();
         let subkey = self.subkeys(hive)?
             .iter()
-            .find(|s|s.borrow().name() == name)
+            .find(|s|s.borrow().name().to_lowercase() == lowercase_name)
             .map(Rc::clone);
         Ok(subkey)
     }


### PR DESCRIPTION
Names of registry keys are not case sensitive. This has been fixed with this PR